### PR TITLE
Code massage

### DIFF
--- a/napari_clij_widget.py
+++ b/napari_clij_widget.py
@@ -39,7 +39,7 @@ with napari.gui_qt():
 
     # use auto_call=True for instantaneous execution
     #can add sliders using QSlider, but need to show values
-    @magicgui(call_button='Compute')
+    @magicgui(auto_call=True, call_button='Compute')
     def clij_filter(input: Image, operation: gpu_filter, x: float = 0, y: float = 0,
                     z: float = 0) -> Image:
         if input:

--- a/napari_clij_widget.py
+++ b/napari_clij_widget.py
@@ -46,10 +46,10 @@ with napari.gui_qt():
     def clij_filter(input: Image, operation: gpu_filter, x: float = 0, y: float = 0,
                     z: float = 0) -> Image:
         if input:
-            cle_input = cle.push(input.data)
+            cle_input = cle.push_zyx(input.data)
             operation = filters[operation];
 
-            output = cle.create_like(input.data)
+            output = cle.create_like(cle_input)
             # concatenate the vale from gpu_operation  as a string
             #command = operation.value + "(cle_input, output, x, y, z)"
             # use evaluate to execute the command

--- a/napari_clij_widget.py
+++ b/napari_clij_widget.py
@@ -15,23 +15,20 @@ image_3d = io.imread(three_dim)
 
 # Using Enums for getting a dropdown menu
 # clesperanto functions are not being passed as enum values for some reason, so they are defined as strings
-class gpu_filter(Enum):
-    # using pyclesperanto filtering images with a gpu
-    mean = 'cle.mean_sphere'
-    maximum = 'cle.maximum_sphere'
-    minimum = 'cle.minimum_sphere'
-    top_hat = 'cle.top_hat_sphere'
-    gaussian_blur = 'cle.gaussian_blur'
-    crop = 'cle.crop'
+class gpu_filter( Enum):
+    def __new__(cls, value, operation):
+        obj = object.__new__(cls)
+        obj._value_ = operation.__name__
+        obj.operation = operation
+        return obj
 
-filters = {
-    gpu_filter.mean : cle.mean_sphere,
-    gpu_filter.maximum : cle.maximum_sphere,
-    gpu_filter.minimum : cle.minimum_sphere,
-    gpu_filter.top_hat: cle.top_hat_sphere,
-    gpu_filter.gaussian_blur: cle.gaussian_blur,
-    gpu_filter.crop: cle.crop
-}
+    # using pyclesperanto filtering images with a gpu
+    mean =          (0, cle.minimum_sphere)
+    maximum =       (0, cle.maximum_sphere)
+    minimum =       (0, cle.minimum_sphere)
+    top_hat =       (0, cle.top_hat_sphere)
+    gaussian_blur = (0, cle.gaussian_blur)
+    crop =          (0, cle.crop)
 
 
 with napari.gui_qt():
@@ -47,13 +44,9 @@ with napari.gui_qt():
                     z: float = 0) -> Image:
         if input:
             cle_input = cle.push_zyx(input.data)
-            operation = filters[operation];
+            operation = operation.operation #filters[operation]
 
             output = cle.create_like(cle_input)
-            # concatenate the vale from gpu_operation  as a string
-            #command = operation.value + "(cle_input, output, x, y, z)"
-            # use evaluate to execute the command
-            #eval(command)
             operation(cle_input, output, x, y, z)
 
             output = cle.pull_zyx(output)

--- a/napari_clij_widget.py
+++ b/napari_clij_widget.py
@@ -18,7 +18,6 @@ image_3d = io.imread(three_dim)
 class gpu_filter( Enum):
     def __new__(cls, value, operation):
         obj = object.__new__(cls)
-        obj._value_ = operation.__name__
         obj.operation = operation
         return obj
 
@@ -29,12 +28,13 @@ class gpu_filter( Enum):
     top_hat =       (0, cle.top_hat_sphere)
     gaussian_blur = (0, cle.gaussian_blur)
     crop =          (0, cle.crop)
+                     # todo: get rid of the 0
 
 
 with napari.gui_qt():
     viewer = napari.Viewer()
-    viewer.add_image(image_2d, name='2D_image_orig')
     viewer.add_image(image_3d, name='3D_image_orig')
+    viewer.add_image(image_2d, name='2D_image_orig')
 
 
     # use auto_call=True for instantaneous execution
@@ -44,7 +44,7 @@ with napari.gui_qt():
                     z: float = 0) -> Image:
         if input:
             cle_input = cle.push_zyx(input.data)
-            operation = operation.operation #filters[operation]
+            operation = operation.operation
 
             output = cle.create_like(cle_input)
             operation(cle_input, output, x, y, z)

--- a/napari_clij_widget.py
+++ b/napari_clij_widget.py
@@ -56,11 +56,7 @@ with napari.gui_qt():
             #eval(command)
             operation(cle_input, output, x, y, z)
 
-            output = cle.pull(output)
-            print("output shape", output.shape)
-            # reshape image from z,x,y to x,y,z; image is returned as z,x,y from cle push and pull operations
-            output = np.swapaxes(output, 0, -1)
-            print("output shape after reshape ", output.shape)
+            output = cle.pull_zyx(output)
             return output
 
 

--- a/napari_clij_widget.py
+++ b/napari_clij_widget.py
@@ -24,6 +24,15 @@ class gpu_filter(Enum):
     gaussian_blur = 'cle.gaussian_blur'
     crop = 'cle.crop'
 
+filters = {
+    gpu_filter.mean : cle.mean_sphere,
+    gpu_filter.maximum : cle.maximum_sphere,
+    gpu_filter.minimum : cle.minimum_sphere,
+    gpu_filter.top_hat: cle.top_hat_sphere,
+    gpu_filter.gaussian_blur: cle.gaussian_blur,
+    gpu_filter.crop: cle.crop
+}
+
 
 with napari.gui_qt():
     viewer = napari.Viewer()
@@ -38,11 +47,15 @@ with napari.gui_qt():
                     z: float = 0) -> Image:
         if input:
             cle_input = cle.push(input.data)
+            operation = filters[operation];
+
             output = cle.create_like(input.data)
             # concatenate the vale from gpu_operation  as a string
-            command = operation.value + "(cle_input, output, x, y, z)"
+            #command = operation.value + "(cle_input, output, x, y, z)"
             # use evaluate to execute the command
-            eval(command)
+            #eval(command)
+            operation(cle_input, output, x, y, z)
+
             output = cle.pull(output)
             print("output shape", output.shape)
             # reshape image from z,x,y to x,y,z; image is returned as z,x,y from cle push and pull operations


### PR DESCRIPTION
Hey @pr4deepr ,

here come some little changes as answer to your discussion here:
https://github.com/clEsperanto/pyclesperanto_prototype/issues/9

I managed to replace the `eval()` call (which is kind of evil) with a construct inside the Enum. It's also the first time, I use python Enums.

I was also able to replace your shape-transfer code by a cleaner variant. The problem behind is cle.push assumes your image comes in format XYZ (default in CLIJ), hence also cle.pull returns an image in XYZ. However, numpy arrays are usually treated as ZYX and thus, we need to use push_zyx and pull_zyx. I went through similar pain when making clatlab. 

I also added some nice easer egg. I'll put a video in the other discussion.

Cheers,
Robert